### PR TITLE
[Feat] 사용자 카페 취향 저장 및 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,10 @@ repositories {
 	}
 }
 
+ext {
+	set('springAiVersion', "1.0.1")
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -43,6 +47,16 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	//open ai 연결
+	implementation 'org.springframework.ai:spring-ai-starter-model-openai'
+
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.ai:spring-ai-bom:${springAiVersion}"
+	}
 }
 
 tasks.named('test') {

--- a/src/main/java/com/tumbloom/tumblerin/app/controller/AuthController.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/controller/AuthController.java
@@ -15,9 +15,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/users")
+@RequestMapping("/api/auth")
 @RequiredArgsConstructor
-public class UserController {
+public class AuthController {
 
     private final UserService userService;
 

--- a/src/main/java/com/tumbloom/tumblerin/app/controller/MyPageController.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/controller/MyPageController.java
@@ -8,25 +8,28 @@ import com.tumbloom.tumblerin.global.dto.SuccessCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/mypage")
+@RequestMapping("/api/users/me")
 @RequiredArgsConstructor
 public class MyPageController {
 
     private final UserPreferenceService userPreferenceService;
 
-    @PostMapping("/preference")
+    @PostMapping("/preferences")
     public ResponseEntity<?> savePreference(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody UserPreferenceDTO dto) {
 
         userPreferenceService.saveOrUpdate(userDetails.getUser().getId(),dto);
         return ApiResponseTemplate.success(SuccessCode.RESOURCE_UPDATED,null);
+    }
+
+    @GetMapping("/preferences")
+    public ResponseEntity<?> getPreference(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        UserPreferenceDTO preferenceDTO = userPreferenceService.getPreference(userDetails.getUser().getId());
+        return ApiResponseTemplate.success(SuccessCode.RESOURCE_RETRIEVED, preferenceDTO);
     }
 
 }

--- a/src/main/java/com/tumbloom/tumblerin/app/controller/MyPageController.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/controller/MyPageController.java
@@ -1,0 +1,32 @@
+package com.tumbloom.tumblerin.app.controller;
+
+import com.tumbloom.tumblerin.app.dto.UserPreferenceDTO;
+import com.tumbloom.tumblerin.app.security.CustomUserDetails;
+import com.tumbloom.tumblerin.app.service.UserPreferenceService;
+import com.tumbloom.tumblerin.global.dto.ApiResponseTemplate;
+import com.tumbloom.tumblerin.global.dto.SuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/mypage")
+@RequiredArgsConstructor
+public class MyPageController {
+
+    private final UserPreferenceService userPreferenceService;
+
+    @PostMapping("/preference")
+    public ResponseEntity<?> savePreference(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody UserPreferenceDTO dto) {
+
+        userPreferenceService.saveOrUpdate(userDetails.getUser().getId(),dto);
+        return ApiResponseTemplate.success(SuccessCode.RESOURCE_UPDATED,null);
+    }
+
+}

--- a/src/main/java/com/tumbloom/tumblerin/app/domain/Preference/ExtraOption.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/domain/Preference/ExtraOption.java
@@ -1,0 +1,31 @@
+package com.tumbloom.tumblerin.app.domain.Preference;
+
+import com.tumbloom.tumblerin.global.exception.BusinessException;
+import com.tumbloom.tumblerin.global.dto.ErrorCode;
+
+public enum ExtraOption {
+    FRANCHISE("브랜드/프랜차이즈"),
+    PET_FRIENDLY("반려동물 가능"),
+    OUTDOOR_TERRACE("야외/테라스"),
+    ECO_LOCAL("친환경/로컬"),
+    UNIQUE_THEME("이색테마/메뉴");
+
+    private final String korean;
+
+    ExtraOption(String korean) {
+        this.korean = korean;
+    }
+
+    public String getKorean() {
+        return korean;
+    }
+
+    public static ExtraOption fromKorean(String korean) {
+        for (ExtraOption option : values()) {
+            if (option.korean.equals(korean)) {
+                return option;
+            }
+        }
+        throw new BusinessException(ErrorCode.INVALID_REQUEST, "잘못된 한글 라벨입니다.");
+    }
+}

--- a/src/main/java/com/tumbloom/tumblerin/app/domain/Preference/ExtraOption.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/domain/Preference/ExtraOption.java
@@ -4,28 +4,17 @@ import com.tumbloom.tumblerin.global.exception.BusinessException;
 import com.tumbloom.tumblerin.global.dto.ErrorCode;
 
 public enum ExtraOption {
-    FRANCHISE("브랜드/프랜차이즈"),
-    PET_FRIENDLY("반려동물 가능"),
-    OUTDOOR_TERRACE("야외/테라스"),
-    ECO_LOCAL("친환경/로컬"),
-    UNIQUE_THEME("이색테마/메뉴");
+    FRANCHISE,
+    PET_FRIENDLY,
+    OUTDOOR_TERRACE,
+    ECO_LOCAL,
+    UNIQUE_THEME;
 
-    private final String korean;
-
-    ExtraOption(String korean) {
-        this.korean = korean;
-    }
-
-    public String getKorean() {
-        return korean;
-    }
-
-    public static ExtraOption fromKorean(String korean) {
-        for (ExtraOption option : values()) {
-            if (option.korean.equals(korean)) {
-                return option;
-            }
+    public static ExtraOption fromString(String value) {
+        try {
+            return ExtraOption.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST, "잘못된 옵션 값입니다.");
         }
-        throw new BusinessException(ErrorCode.INVALID_REQUEST, "잘못된 한글 라벨입니다.");
     }
 }

--- a/src/main/java/com/tumbloom/tumblerin/app/domain/Preference/PreferredMenu.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/domain/Preference/PreferredMenu.java
@@ -4,28 +4,18 @@ import com.tumbloom.tumblerin.global.dto.ErrorCode;
 import com.tumbloom.tumblerin.global.exception.BusinessException;
 
 public enum PreferredMenu {
-    SPECIALTY("고급/스페셜티"),
-    DESSERT("디저트 맛집"),
-    DECAF("디카페인"),
-    SEASON_MENU("빙수/계절메뉴"),
-    BRUNCH("브런치/식사");
+    SPECIALTY,
+    DESSERT,
+    DECAF,
+    SEASON_MENU,
+    BRUNCH;
 
-    private final String korean;
 
-    PreferredMenu(String korean) {
-        this.korean = korean;
-    }
-
-    public String getKorean() {
-        return korean;
-    }
-
-    public static PreferredMenu fromKorean(String korean) {
-        for (PreferredMenu menu : values()) {
-            if (menu.korean.equals(korean)) {
-                return menu;
-            }
+    public static ExtraOption fromString(String value) {
+        try {
+            return ExtraOption.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST, "잘못된 옵션 값입니다.");
         }
-        throw new BusinessException(ErrorCode.INVALID_REQUEST, "잘못된 한글 라벨입니다.");
     }
 }

--- a/src/main/java/com/tumbloom/tumblerin/app/domain/Preference/PreferredMenu.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/domain/Preference/PreferredMenu.java
@@ -1,0 +1,31 @@
+package com.tumbloom.tumblerin.app.domain.Preference;
+
+import com.tumbloom.tumblerin.global.dto.ErrorCode;
+import com.tumbloom.tumblerin.global.exception.BusinessException;
+
+public enum PreferredMenu {
+    SPECIALTY("고급/스페셜티"),
+    DESSERT("디저트 맛집"),
+    DECAF("디카페인"),
+    SEASON_MENU("빙수/계절메뉴"),
+    BRUNCH("브런치/식사");
+
+    private final String korean;
+
+    PreferredMenu(String korean) {
+        this.korean = korean;
+    }
+
+    public String getKorean() {
+        return korean;
+    }
+
+    public static PreferredMenu fromKorean(String korean) {
+        for (PreferredMenu menu : values()) {
+            if (menu.korean.equals(korean)) {
+                return menu;
+            }
+        }
+        throw new BusinessException(ErrorCode.INVALID_REQUEST, "잘못된 한글 라벨입니다.");
+    }
+}

--- a/src/main/java/com/tumbloom/tumblerin/app/domain/Preference/VisitPurpose.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/domain/Preference/VisitPurpose.java
@@ -1,0 +1,30 @@
+package com.tumbloom.tumblerin.app.domain.Preference;
+
+import com.tumbloom.tumblerin.global.dto.ErrorCode;
+import com.tumbloom.tumblerin.global.exception.BusinessException;
+
+public enum VisitPurpose {
+    EMOTIONAL_ATMOSPHERE("감성/분위기"),
+    STUDY_WORKSPACE("공부/작업공간"),
+    CHAT_MEETING("수다/모임"),
+    HOT_PLACE("HOT플레이스");
+
+    private final String korean;
+
+    VisitPurpose(String korean) {
+        this.korean = korean;
+    }
+
+    public String getKorean() {
+        return korean;
+    }
+
+    public static VisitPurpose fromKorean(String korean) {
+        for (VisitPurpose purpose : values()) {
+            if (purpose.korean.equals(korean)) {
+                return purpose;
+            }
+        }
+        throw new BusinessException(ErrorCode.INVALID_REQUEST, "잘못된 한글 라벨입니다.");
+    }
+}

--- a/src/main/java/com/tumbloom/tumblerin/app/domain/Preference/VisitPurpose.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/domain/Preference/VisitPurpose.java
@@ -4,27 +4,16 @@ import com.tumbloom.tumblerin.global.dto.ErrorCode;
 import com.tumbloom.tumblerin.global.exception.BusinessException;
 
 public enum VisitPurpose {
-    EMOTIONAL_ATMOSPHERE("감성/분위기"),
-    STUDY_WORKSPACE("공부/작업공간"),
-    CHAT_MEETING("수다/모임"),
-    HOT_PLACE("HOT플레이스");
+    EMOTIONAL_ATMOSPHERE,
+    STUDY_WORKSPACE,
+    CHAT_MEETING,
+    HOT_PLACE;
 
-    private final String korean;
-
-    VisitPurpose(String korean) {
-        this.korean = korean;
-    }
-
-    public String getKorean() {
-        return korean;
-    }
-
-    public static VisitPurpose fromKorean(String korean) {
-        for (VisitPurpose purpose : values()) {
-            if (purpose.korean.equals(korean)) {
-                return purpose;
-            }
+    public static ExtraOption fromString(String value) {
+        try {
+            return ExtraOption.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST, "잘못된 옵션 값입니다.");
         }
-        throw new BusinessException(ErrorCode.INVALID_REQUEST, "잘못된 한글 라벨입니다.");
     }
 }

--- a/src/main/java/com/tumbloom/tumblerin/app/domain/User.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/domain/User.java
@@ -27,4 +27,7 @@ public class User {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private RoleType roleType;
+
+    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private UserPreference userPreference;
 }

--- a/src/main/java/com/tumbloom/tumblerin/app/domain/UserPreference.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/domain/UserPreference.java
@@ -1,0 +1,31 @@
+package com.tumbloom.tumblerin.app.domain;
+
+import com.tumbloom.tumblerin.app.domain.Preference.ExtraOption;
+import com.tumbloom.tumblerin.app.domain.Preference.PreferredMenu;
+import com.tumbloom.tumblerin.app.domain.Preference.VisitPurpose;
+import jakarta.persistence.*;
+
+import java.util.List;
+
+@Table(name = "user_preference")
+@Entity
+public class UserPreference {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @ElementCollection
+    @Enumerated(EnumType.STRING)
+    private List<VisitPurpose> visitPurposes;
+
+    @ElementCollection
+    @Enumerated(EnumType.STRING)
+    private List<PreferredMenu> preferredMenus;
+
+    @ElementCollection
+    @Enumerated(EnumType.STRING)
+    private List<ExtraOption> extraOptions;
+}

--- a/src/main/java/com/tumbloom/tumblerin/app/domain/UserPreference.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/domain/UserPreference.java
@@ -7,8 +7,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.util.List;
+import java.util.Set;
 
 @Table(name = "user_preference")
 @Entity
@@ -23,15 +22,15 @@ public class UserPreference {
     @OneToOne(fetch = FetchType.LAZY)
     private User user;
 
-    @ElementCollection(fetch = FetchType.EAGER)
+    @ElementCollection(fetch = FetchType.LAZY)
     @Enumerated(EnumType.STRING)
-    private List<VisitPurpose> visitPurposes;
+    private Set<VisitPurpose> visitPurposes;
 
-    @ElementCollection(fetch = FetchType.EAGER)
+    @ElementCollection(fetch = FetchType.LAZY)
     @Enumerated(EnumType.STRING)
-    private List<PreferredMenu> preferredMenus;
+    private Set<PreferredMenu> preferredMenus;
 
-    @ElementCollection(fetch = FetchType.EAGER)
+    @ElementCollection(fetch = FetchType.LAZY)
     @Enumerated(EnumType.STRING)
-    private List<ExtraOption> extraOptions;
+    private Set<ExtraOption> extraOptions;
 }

--- a/src/main/java/com/tumbloom/tumblerin/app/domain/UserPreference.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/domain/UserPreference.java
@@ -23,15 +23,15 @@ public class UserPreference {
     @OneToOne(fetch = FetchType.LAZY)
     private User user;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     @Enumerated(EnumType.STRING)
     private List<VisitPurpose> visitPurposes;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     @Enumerated(EnumType.STRING)
     private List<PreferredMenu> preferredMenus;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     @Enumerated(EnumType.STRING)
     private List<ExtraOption> extraOptions;
 }

--- a/src/main/java/com/tumbloom/tumblerin/app/domain/UserPreference.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/domain/UserPreference.java
@@ -4,11 +4,17 @@ import com.tumbloom.tumblerin.app.domain.Preference.ExtraOption;
 import com.tumbloom.tumblerin.app.domain.Preference.PreferredMenu;
 import com.tumbloom.tumblerin.app.domain.Preference.VisitPurpose;
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.List;
 
 @Table(name = "user_preference")
 @Entity
+@Getter
+@Setter
+@NoArgsConstructor
 public class UserPreference {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/tumbloom/tumblerin/app/dto/UserPreferenceDTO.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/dto/UserPreferenceDTO.java
@@ -1,0 +1,16 @@
+package com.tumbloom.tumblerin.app.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserPreferenceDTO {
+    private List<String> visitPurposes;
+    private List<String> preferredMenus;
+    private List<String> extraOptions;
+}

--- a/src/main/java/com/tumbloom/tumblerin/app/repository/UserPreferenceRepository.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/repository/UserPreferenceRepository.java
@@ -3,6 +3,7 @@ package com.tumbloom.tumblerin.app.repository;
 import com.tumbloom.tumblerin.app.domain.User;
 import com.tumbloom.tumblerin.app.domain.UserPreference;
 import com.tumbloom.tumblerin.app.dto.UserPreferenceDTO;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,6 +16,10 @@ public interface UserPreferenceRepository extends JpaRepository<UserPreference, 
     Optional<UserPreference> findByUser(User user);
 
     //LazyInitializationException 우회 추후 성능 저하 발생시 ->  JPQL 또는 QueryDSL 활용
-    @Query("select up from UserPreference up join fetch up.visitPurposes join fetch up.preferredMenus join fetch up.extraOptions where up.user.id = :userId")
-    Optional<UserPreference> findByUserIdFetchJoin(@Param("userId") Long userId);
+    @EntityGraph(attributePaths = {
+    "visitPurposes",
+    "preferredMenus",
+    "extraOptions"
+    })
+    Optional<UserPreference> findDetailByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/tumbloom/tumblerin/app/repository/UserPreferenceRepository.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/repository/UserPreferenceRepository.java
@@ -2,7 +2,10 @@ package com.tumbloom.tumblerin.app.repository;
 
 import com.tumbloom.tumblerin.app.domain.User;
 import com.tumbloom.tumblerin.app.domain.UserPreference;
+import com.tumbloom.tumblerin.app.dto.UserPreferenceDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -10,4 +13,8 @@ public interface UserPreferenceRepository extends JpaRepository<UserPreference, 
 
     //null도 감쌀 수 있어야 되니가 Optional
     Optional<UserPreference> findByUser(User user);
+
+    //LazyInitializationException 우회 추후 성능 저하 발생시 ->  JPQL 또는 QueryDSL 활용
+    @Query("select up from UserPreference up join fetch up.visitPurposes join fetch up.preferredMenus join fetch up.extraOptions where up.user.id = :userId")
+    Optional<UserPreference> findByUserIdFetchJoin(@Param("userId") Long userId);
 }

--- a/src/main/java/com/tumbloom/tumblerin/app/repository/UserPreferenceRepository.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/repository/UserPreferenceRepository.java
@@ -1,0 +1,7 @@
+package com.tumbloom.tumblerin.app.repository;
+
+import com.tumbloom.tumblerin.app.domain.UserPreference;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserPreferenceRepository extends JpaRepository<UserPreference, Long> {
+}

--- a/src/main/java/com/tumbloom/tumblerin/app/repository/UserPreferenceRepository.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/repository/UserPreferenceRepository.java
@@ -1,7 +1,13 @@
 package com.tumbloom.tumblerin.app.repository;
 
+import com.tumbloom.tumblerin.app.domain.User;
 import com.tumbloom.tumblerin.app.domain.UserPreference;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserPreferenceRepository extends JpaRepository<UserPreference, Long> {
+
+    //null도 감쌀 수 있어야 되니가 Optional
+    Optional<UserPreference> findByUser(User user);
 }

--- a/src/main/java/com/tumbloom/tumblerin/app/service/UserPreferenceService.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/service/UserPreferenceService.java
@@ -13,8 +13,7 @@ import com.tumbloom.tumblerin.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -35,9 +34,9 @@ public class UserPreferenceService {
                     return up;
                 });
 
-        preference.setVisitPurposes(convertToVisitPurposeEnum(dto.getVisitPurposes()));
-        preference.setPreferredMenus(convertToPreferredMenuEnum(dto.getPreferredMenus()));
-        preference.setExtraOptions(convertToExtraOptionEnum(dto.getExtraOptions()));
+        preference.setVisitPurposes(convertToVisitPurposeEnum(new HashSet<>(dto.getVisitPurposes())));
+        preference.setPreferredMenus(convertToPreferredMenuEnum(new HashSet<>(dto.getPreferredMenus())));
+        preference.setExtraOptions(convertToExtraOptionEnum(new HashSet<>(dto.getExtraOptions())));
 
         userPreferenceRepository.save(preference);
 
@@ -49,7 +48,7 @@ public class UserPreferenceService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        UserPreference preference = userPreferenceRepository.findByUser(user).orElse(null);
+        UserPreference preference = userPreferenceRepository.findDetailByUserId(userId).orElse(null);
 
         if (preference == null) {
             // 아직 등록된 취향이 없으면 빈 리스트로 반환
@@ -72,27 +71,27 @@ public class UserPreferenceService {
 
 
     //string을 enum 값으로 변환
-    private List<VisitPurpose> convertToVisitPurposeEnum(List<String> list) {
+    private Set<VisitPurpose> convertToVisitPurposeEnum(Set<String> list) {
         return list.stream()
                 .map(VisitPurpose::valueOf)
-                .collect(Collectors.toList());
+                .collect(Collectors.toSet());
     }
 
-    private List<PreferredMenu> convertToPreferredMenuEnum(List<String> list) {
+    private Set<PreferredMenu> convertToPreferredMenuEnum(Set<String> list) {
         return list.stream()
                 .map(PreferredMenu::valueOf)
-                .collect(Collectors.toList());
+                .collect(Collectors.toSet());
     }
 
-    private List<ExtraOption> convertToExtraOptionEnum(List<String> list) {
+    private Set<ExtraOption> convertToExtraOptionEnum(Set<String> list) {
         return list.stream()
                 .map(ExtraOption::valueOf)
-                .collect(Collectors.toList());
+                .collect(Collectors.toSet());
     }
 
     //enum 값을 string으로 변환
-    private <T extends Enum<T>> List<String> convertEnumToStringList(List<T> enumList) {
-        return enumList.stream()
+    private <T extends Enum<T>> List<String> convertEnumToStringList(Collection<T> enumCollection) {
+        return enumCollection.stream()
                 .map(Enum::name)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/tumbloom/tumblerin/app/service/UserPreferenceService.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/service/UserPreferenceService.java
@@ -13,6 +13,7 @@ import com.tumbloom.tumblerin.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -43,6 +44,33 @@ public class UserPreferenceService {
 
     }
 
+    //사용자 취향 조회
+    public UserPreferenceDTO getPreference(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        UserPreference preference = userPreferenceRepository.findByUser(user).orElse(null);
+
+        if (preference == null) {
+            // 아직 등록된 취향이 없으면 빈 리스트로 반환
+            return UserPreferenceDTO.builder()
+                    .visitPurposes(Collections.emptyList())
+                    .preferredMenus(Collections.emptyList())
+                    .extraOptions(Collections.emptyList())
+                    .build();
+        }
+
+        return UserPreferenceDTO.builder()
+                .visitPurposes(convertEnumToStringList(preference.getVisitPurposes()))
+                .preferredMenus(convertEnumToStringList(preference.getPreferredMenus()))
+                .extraOptions(convertEnumToStringList(preference.getExtraOptions()))
+                .build();
+    }
+
+
+
+
+
     //string을 enum 값으로 변환
     private List<VisitPurpose> convertToVisitPurposeEnum(List<String> list) {
         return list.stream()
@@ -65,7 +93,7 @@ public class UserPreferenceService {
     //enum 값을 string으로 변환
     private <T extends Enum<T>> List<String> convertEnumToStringList(List<T> enumList) {
         return enumList.stream()
-                .map(Enum::name)  // Enum 이름 (예: "EMOTIONAL_ATMOSPHERE")을 String으로 변환
+                .map(Enum::name)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/tumbloom/tumblerin/app/service/UserPreferenceService.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/service/UserPreferenceService.java
@@ -1,0 +1,74 @@
+package com.tumbloom.tumblerin.app.service;
+
+import com.tumbloom.tumblerin.app.domain.Preference.ExtraOption;
+import com.tumbloom.tumblerin.app.domain.Preference.PreferredMenu;
+import com.tumbloom.tumblerin.app.domain.Preference.VisitPurpose;
+import com.tumbloom.tumblerin.app.domain.User;
+import com.tumbloom.tumblerin.app.domain.UserPreference;
+import com.tumbloom.tumblerin.app.dto.UserPreferenceDTO;
+import com.tumbloom.tumblerin.app.repository.UserPreferenceRepository;
+import com.tumbloom.tumblerin.app.repository.UserRepository;
+import com.tumbloom.tumblerin.global.dto.ErrorCode;
+import com.tumbloom.tumblerin.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class UserPreferenceService {
+    private final UserRepository userRepository;
+    private final UserPreferenceRepository userPreferenceRepository;
+
+    //저장(업데이트)
+    public void saveOrUpdate(Long userId, UserPreferenceDTO dto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        UserPreference preference = userPreferenceRepository.findByUser(user)
+                .orElseGet(() -> {
+                    UserPreference up = new UserPreference();
+                    up.setUser(user);
+                    return up;
+                });
+
+        preference.setVisitPurposes(convertToVisitPurposeEnum(dto.getVisitPurposes()));
+        preference.setPreferredMenus(convertToPreferredMenuEnum(dto.getPreferredMenus()));
+        preference.setExtraOptions(convertToExtraOptionEnum(dto.getExtraOptions()));
+
+        userPreferenceRepository.save(preference);
+
+
+    }
+
+    //string을 enum 값으로 변환
+    private List<VisitPurpose> convertToVisitPurposeEnum(List<String> list) {
+        return list.stream()
+                .map(VisitPurpose::valueOf)
+                .collect(Collectors.toList());
+    }
+
+    private List<PreferredMenu> convertToPreferredMenuEnum(List<String> list) {
+        return list.stream()
+                .map(PreferredMenu::valueOf)
+                .collect(Collectors.toList());
+    }
+
+    private List<ExtraOption> convertToExtraOptionEnum(List<String> list) {
+        return list.stream()
+                .map(ExtraOption::valueOf)
+                .collect(Collectors.toList());
+    }
+
+    //enum 값을 string으로 변환
+    private <T extends Enum<T>> List<String> convertEnumToStringList(List<T> enumList) {
+        return enumList.stream()
+                .map(Enum::name)  // Enum 이름 (예: "EMOTIONAL_ATMOSPHERE")을 String으로 변환
+                .collect(Collectors.toList());
+    }
+
+
+}
+

--- a/src/main/java/com/tumbloom/tumblerin/global/config/SecurityConfig.java
+++ b/src/main/java/com/tumbloom/tumblerin/global/config/SecurityConfig.java
@@ -35,8 +35,8 @@ public class SecurityConfig {
                                 "/swagger-resources",
                                 "/webjars/**",
                                 "/configuration/**",
-                                "/api/users/signup",
-                                "/api/users/login"
+                                "/api/auth/signup",
+                                "/api/auth/login"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/tumbloom/tumblerin/global/dto/ErrorCode.java
+++ b/src/main/java/com/tumbloom/tumblerin/global/dto/ErrorCode.java
@@ -16,7 +16,9 @@ public enum ErrorCode {
     ACCESS_DENIED_EXCEPTION(HttpStatus.FORBIDDEN, "해당 리소스에 대한 접근 권한이 없습니다."),
     ALREADY_EXIST_SUBJECT_EXCEPTION(HttpStatus.CONFLICT, "이미 존재하는 리소스입니다."),
     SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "서버가 일시적으로 사용 불가 상태입니다."),
-    UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 서버 에러가 발생했습니다.");
+    UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 서버 에러가 발생했습니다."),
+
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾지 못했습니다. 토큰이 유효한지 확인해주세요.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/tumbloom/tumblerin/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tumbloom/tumblerin/global/security/JwtAuthenticationFilter.java
@@ -24,8 +24,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
 
     private static final String[] WHITE_LIST = {
-            "/api/users/signup",
-            "/api/users/login",
+            "/api/auth/signup",
+            "/api/auth/login",
             "/swagger-ui/**",
             "/v3/api-docs/**",
             "/v3/api-docs",

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,11 @@
 spring:
   application:
     name: tumblerin
+  ai:
+    openai:
+      api-key: ${OPENAI_API_KEY}   # 환경변수에서 API 키 읽기
+      embedding:
+        model: text-embedding-3-small  # 추후 성능 개선 필요시 large로 개선
   profiles:
     active: dev  # 기본적으로 dev 프로파일을 활성화
 


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #14

## ✨ 개발 내용
<!-- 과제에 대한 설명을 적어주세요 -->

1. 사용자에게 마이페이지에서 취향을 입력받아 저장하는 api
2. 사용자의 저장된 취향을 조회하는 api

이를 위해서, 일단 userpreference entity를 만들어 진행하였고 추후 ai 연동을 위해 각 카테고리별 태그들을 다 enum으로 만들어 처리하였습니다.  ai와 연동하면서 service단의 코드가 수정될 수 있으니 참고 부탁드립니다!

