### PR TITLE
[Feat] Userinfo 조회 api 구현

### DIFF
--- a/src/main/java/com/tumbloom/tumblerin/app/controller/MyPageController.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/controller/MyPageController.java
@@ -1,8 +1,10 @@
 package com.tumbloom.tumblerin.app.controller;
 import com.tumbloom.tumblerin.app.dto.Cafedto.CafeRecommendDTO;
 import com.tumbloom.tumblerin.app.dto.UserPreferenceDTO;
+import com.tumbloom.tumblerin.app.dto.Userdto.UserMyPageResponseDTO;
 import com.tumbloom.tumblerin.app.security.CustomUserDetails;
 import com.tumbloom.tumblerin.app.service.CafeRecommendationService;
+import com.tumbloom.tumblerin.app.service.MyPageService;
 import com.tumbloom.tumblerin.app.service.UserPreferenceService;
 import com.tumbloom.tumblerin.global.dto.ApiResponseTemplate;
 import com.tumbloom.tumblerin.global.dto.SuccessCode;
@@ -11,7 +13,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/users/me")
@@ -20,6 +24,34 @@ public class MyPageController {
 
     private final UserPreferenceService userPreferenceService;
     private final CafeRecommendationService cafeRecommendationService;
+    private final MyPageService myPageService;
+
+    @GetMapping("")
+    public ResponseEntity<?> getUserInfo(@AuthenticationPrincipal CustomUserDetails userDetails){
+        UserMyPageResponseDTO userinfo = myPageService.getUserInfo(userDetails.getUser().getId());
+        UserPreferenceDTO preference = userPreferenceService.getPreference(userDetails.getUser().getId());
+
+        //user 취향 항목 조회에서 3개만 꺼내와서 조합
+        List<String> combined = new ArrayList<>();
+        combined.addAll(preference.getPreferredMenus());
+        combined.addAll(preference.getVisitPurposes());
+        combined.addAll(preference.getExtraOptions());
+
+        List<String> topPreferences = combined.stream()
+                .limit(3)
+                .collect(Collectors.toList());
+
+        userinfo.setTopPreferences(topPreferences);
+
+        // levelProgress 계산
+        int min = MyPageService.getMinStampsForLevel(userinfo.getLevel());
+        int max = MyPageService.getMaxStampsForLevel(userinfo.getLevel());
+        double progress = (double)(userinfo.getTumblerUsageCount() - min) / (max - min);
+        userinfo.setLevelProgress(Math.min(progress, 1.0));  // 최대 1.0으로 제한
+
+        return ApiResponseTemplate.success(SuccessCode.RESOURCE_RETRIEVED, userinfo);
+    }
+
 
     @PostMapping("/preferences")
     public ResponseEntity<?> savePreference(
@@ -32,8 +64,8 @@ public class MyPageController {
 
     @GetMapping("/preferences")
     public ResponseEntity<?> getPreference(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        UserPreferenceDTO preferenceDTO = userPreferenceService.getPreference(userDetails.getUser().getId());
-        return ApiResponseTemplate.success(SuccessCode.RESOURCE_RETRIEVED, preferenceDTO);
+        UserPreferenceDTO preference = userPreferenceService.getPreference(userDetails.getUser().getId());
+        return ApiResponseTemplate.success(SuccessCode.RESOURCE_RETRIEVED, preference);
     }
 
     @GetMapping("/cafe-recommendations")

--- a/src/main/java/com/tumbloom/tumblerin/app/controller/MyPageController.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/controller/MyPageController.java
@@ -1,6 +1,6 @@
 package com.tumbloom.tumblerin.app.controller;
 import com.tumbloom.tumblerin.app.dto.Cafedto.CafeRecommendDTO;
-import com.tumbloom.tumblerin.app.dto.UserPreferenceDTO;
+import com.tumbloom.tumblerin.app.dto.Userdto.UserPreferenceDTO;
 import com.tumbloom.tumblerin.app.dto.Userdto.UserMyPageResponseDTO;
 import com.tumbloom.tumblerin.app.security.CustomUserDetails;
 import com.tumbloom.tumblerin.app.service.CafeRecommendationService;

--- a/src/main/java/com/tumbloom/tumblerin/app/dto/Userdto/UserMyPageResponseDTO.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/dto/Userdto/UserMyPageResponseDTO.java
@@ -2,15 +2,23 @@ package com.tumbloom.tumblerin.app.dto.Userdto;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
 
 @Getter
+@Setter
 @Builder
 public class UserMyPageResponseDTO {
     private String nickname;
-    private int level;
+    private String level;
     private int remainingSteps;
     private int tumblerUsageCount;
     private int couponIssuedCount;
     private int availableCoupons;
     private int favoriteCafeCount;
+
+    private List<String> topPreferences;
+    private double levelProgress;
+
 }

--- a/src/main/java/com/tumbloom/tumblerin/app/dto/Userdto/UserMyPageResponseDTO.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/dto/Userdto/UserMyPageResponseDTO.java
@@ -1,0 +1,16 @@
+package com.tumbloom.tumblerin.app.dto.Userdto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserMyPageResponseDTO {
+    private String nickname;
+    private int level;
+    private int remainingSteps;
+    private int tumblerUsageCount;
+    private int couponIssuedCount;
+    private int availableCoupons;
+    private int favoriteCafeCount;
+}

--- a/src/main/java/com/tumbloom/tumblerin/app/dto/Userdto/UserPreferenceDTO.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/dto/Userdto/UserPreferenceDTO.java
@@ -1,4 +1,4 @@
-package com.tumbloom.tumblerin.app.dto;
+package com.tumbloom.tumblerin.app.dto.Userdto;
 
 import lombok.*;
 

--- a/src/main/java/com/tumbloom/tumblerin/app/repository/CouponRepository.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/repository/CouponRepository.java
@@ -1,4 +1,10 @@
 package com.tumbloom.tumblerin.app.repository;
 
-public interface CouponRepository {
+import com.tumbloom.tumblerin.app.domain.Coupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+    int countByUserId(Long userId); // 누적 발급 횟수
+
+    int countByUserIdAndIsUsedFalse(Long userId); // 사용 가능한 쿠폰 수
 }

--- a/src/main/java/com/tumbloom/tumblerin/app/repository/FavoriteRepository.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/repository/FavoriteRepository.java
@@ -19,4 +19,6 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
     @Query("SELECT f.cafe.id FROM Favorite f WHERE f.user.id = :userId")
     List<Long> findCafeIdsByUserId(Long userId);
 
+    int countByUserId(Long userId);
+
 }

--- a/src/main/java/com/tumbloom/tumblerin/app/repository/StampRepository.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/repository/StampRepository.java
@@ -1,0 +1,8 @@
+package com.tumbloom.tumblerin.app.repository;
+
+import com.tumbloom.tumblerin.app.domain.Stamp;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StampRepository extends JpaRepository<Stamp, Long> {
+    int countByUserId(Long userId);
+}

--- a/src/main/java/com/tumbloom/tumblerin/app/repository/UserPreferenceRepository.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/repository/UserPreferenceRepository.java
@@ -2,10 +2,8 @@ package com.tumbloom.tumblerin.app.repository;
 
 import com.tumbloom.tumblerin.app.domain.User;
 import com.tumbloom.tumblerin.app.domain.UserPreference;
-import com.tumbloom.tumblerin.app.dto.UserPreferenceDTO;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;

--- a/src/main/java/com/tumbloom/tumblerin/app/service/MyPageService.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/service/MyPageService.java
@@ -1,0 +1,87 @@
+package com.tumbloom.tumblerin.app.service;
+
+import com.tumbloom.tumblerin.app.domain.User;
+import com.tumbloom.tumblerin.app.dto.Userdto.UserMyPageResponseDTO;
+import com.tumbloom.tumblerin.app.repository.CouponRepository;
+import com.tumbloom.tumblerin.app.repository.FavoriteRepository;
+import com.tumbloom.tumblerin.app.repository.StampRepository;
+import com.tumbloom.tumblerin.app.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+
+    private final UserRepository userRepository;
+    private final CouponRepository couponRepository;
+    private final StampRepository stampRepository;
+    private final FavoriteRepository favoriteRepository;
+
+    @Transactional(readOnly = true)
+    public UserMyPageResponseDTO getUserInfo(Long userId){
+
+        var user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        int tumblerUsageCount = stampRepository.countByUserId(userId);
+        int couponIssuedCount = couponRepository.countByUserId(userId);
+        int availableCoupons = couponRepository.countByUserIdAndIsUsedFalse(userId);
+        int favoriteCafeCount = favoriteRepository.countByUserId(userId);
+        String levelName = getLevelName(tumblerUsageCount);
+        int remaining = remainingToNextLevel(tumblerUsageCount);
+
+
+        return UserMyPageResponseDTO.builder()
+                .nickname(user.getNickname())
+                .level(levelName)
+                .remainingSteps(remaining)
+                .tumblerUsageCount(tumblerUsageCount)
+                .couponIssuedCount(couponIssuedCount)
+                .availableCoupons(availableCoupons)
+                .favoriteCafeCount(favoriteCafeCount)
+                .build();
+
+    }
+
+    public static String getLevelName(int stampCount) {
+        if (stampCount <= 4) return "Lv1. 텀블러 뉴비";
+        else if (stampCount <= 10) return "Lv2. 텀블러 입문자";
+        else if (stampCount <= 20) return "Lv3. 텀블러 러버";
+        else if (stampCount <= 40) return "Lv4. 텀블러 고수";
+        else return "Lv5. 텀블러 히어로";
+    }
+
+    public static int remainingToNextLevel(int stampCount) {
+        if (stampCount <= 4) return 5 - stampCount;
+        else if (stampCount <= 10) return 11 - stampCount;
+        else if (stampCount <= 20) return 21 - stampCount;
+        else if (stampCount <= 40) return 41 - stampCount;
+        else return 0;
+    }
+
+    public static int getMinStampsForLevel(String level) {
+        return switch(level) {
+            case "Lv1. 텀블러 뉴비" -> 0;
+            case "Lv2. 텀블러 입문자" -> 5;
+            case "Lv3. 텀블러 러버" -> 11;
+            case "Lv4. 텀블러 고수" -> 21;
+            case "Lv5. 텀블러 히어로" -> 41;
+            default -> 0;
+        };
+    }
+
+    public static int getMaxStampsForLevel(String level) {
+        return switch(level) {
+            case "Lv1. 텀블러 뉴비" -> 5;
+            case "Lv2. 텀블러 입문자" -> 11;
+            case "Lv3. 텀블러 러버" -> 21;
+            case "Lv4. 텀블러 고수" -> 41;
+            case "Lv5. 텀블러 히어로" -> 41;  // 마지막 레벨은 고정
+            default -> 0;
+        };
+    }
+
+
+}

--- a/src/main/java/com/tumbloom/tumblerin/app/service/UserPreferenceService.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/service/UserPreferenceService.java
@@ -5,7 +5,7 @@ import com.tumbloom.tumblerin.app.domain.Preference.PreferredMenu;
 import com.tumbloom.tumblerin.app.domain.Preference.VisitPurpose;
 import com.tumbloom.tumblerin.app.domain.User;
 import com.tumbloom.tumblerin.app.domain.UserPreference;
-import com.tumbloom.tumblerin.app.dto.UserPreferenceDTO;
+import com.tumbloom.tumblerin.app.dto.Userdto.UserPreferenceDTO;
 import com.tumbloom.tumblerin.app.repository.UserPreferenceRepository;
 import com.tumbloom.tumblerin.app.repository.UserRepository;
 import com.tumbloom.tumblerin.global.dto.ErrorCode;


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #17 


## ✨ 체크리스트
<!-- 과제에 대한 설명을 적어주세요 -->

- [x] 사용자의 nickname
- [x] 스탬프 : 사용자의  레벨 배정
- [x] 스탬프 :사용자의 레벨 progress 정도 반환
- [x] 스탬프 : 사용자의 누적 stamp 합
- [x] 쿠폰 : 누적 쿠폰 발급량과 가용 쿠폰 수 반환
- [x] 즐겨찾기로 등록한 카페 수 반환
- [x] 내 카페 취향을 기존 조회 api에서 custom에서 상위 3개만 반환하도록 하였습니다.


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 --> 
이번 구현 과정에서 예상보다 많은 util 메서드가 필요함을 느꼈습니다.
특히, 서비스 단에서 util 메서드를 어느 정도까지 분리할지, 무엇이 비즈니스 로직에 속하고 무엇이 컨트롤러 단에서 처리할 UI용 조합 로직인지 고민하게 되었습니다.

조사와 고민 끝에 다음과 같이 결정했습니다.

- 레벨 계산과 같은 비즈니스 로직 → 서비스 단에서 처리

- 프로그레스 바 계산 등 UI용 유틸 정보 → 컨트롤러 단에서 조합

이렇게 역할을 명확히 분리하여 구현하였습니다.