### PR TITLE
[Feat]: refresh token 도입에 따른 로직 수정

### DIFF
--- a/src/main/java/com/tumbloom/tumblerin/app/controller/AuthController.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/controller/AuthController.java
@@ -1,11 +1,11 @@
 package com.tumbloom.tumblerin.app.controller;
 
+import com.tumbloom.tumblerin.app.dto.Authdto.*;
+import com.tumbloom.tumblerin.app.repository.RefreshTokenRepository;
 import com.tumbloom.tumblerin.app.service.UserService;
-import com.tumbloom.tumblerin.app.dto.Authdto.LoginRequestDTO;
-import com.tumbloom.tumblerin.app.dto.Authdto.LoginResponseDTO;
-import com.tumbloom.tumblerin.app.dto.Authdto.SignupRequestDTO;
 import com.tumbloom.tumblerin.global.dto.ApiResponseTemplate;
 import com.tumbloom.tumblerin.global.dto.SuccessCode;
+import com.tumbloom.tumblerin.global.security.JwtTokenProvider;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +20,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final UserService userService;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/signup")
     public ResponseEntity<?> signup(@Valid @RequestBody SignupRequestDTO requestDto) {
@@ -29,12 +31,20 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody LoginRequestDTO request) {
-        LoginResponseDTO response= userService.login(request);
+        TokenResponseDTO response= userService.login(request);
         return ApiResponseTemplate.success(SuccessCode.LOGIN_SUCCESSFUL, response);
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<?> logout() {
+    public ResponseEntity<?> logout(@Valid @RequestBody RefreshRequestDTO request) {
+        userService.logout(request.getRefreshToken());
         return ApiResponseTemplate.success(SuccessCode.LOGOUT_SUCCESSFUL, null);
     }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refresh(@RequestBody RefreshRequestDTO request) {
+        TokenResponseDTO response = userService.refresh(request.getRefreshToken());
+        return ApiResponseTemplate.success(SuccessCode.TOKEN_REFRESHED, response);
+    }
+
 }

--- a/src/main/java/com/tumbloom/tumblerin/app/domain/RefreshToken.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/domain/RefreshToken.java
@@ -1,0 +1,20 @@
+package com.tumbloom.tumblerin.app.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.*;
+
+import java.util.Date;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RefreshToken {
+    @Id
+    private String email;
+    private String refreshToken;
+    private Date expiryDate;
+
+}

--- a/src/main/java/com/tumbloom/tumblerin/app/dto/Authdto/RefreshRequestDTO.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/dto/Authdto/RefreshRequestDTO.java
@@ -2,11 +2,11 @@ package com.tumbloom.tumblerin.app.dto.Authdto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
-public class LoginResponseDTO {
-
-    private String accessToken;
-
+public class RefreshRequestDTO {
+    private String refreshToken;
 }

--- a/src/main/java/com/tumbloom/tumblerin/app/dto/Authdto/TokenResponseDTO.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/dto/Authdto/TokenResponseDTO.java
@@ -1,0 +1,13 @@
+package com.tumbloom.tumblerin.app.dto.Authdto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenResponseDTO {
+
+    private String accessToken;
+    private String refreshToken;
+
+}

--- a/src/main/java/com/tumbloom/tumblerin/app/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/repository/RefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package com.tumbloom.tumblerin.app.repository;
+
+import com.tumbloom.tumblerin.app.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
+
+}

--- a/src/main/java/com/tumbloom/tumblerin/global/config/SecurityConfig.java
+++ b/src/main/java/com/tumbloom/tumblerin/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.tumbloom.tumblerin.global.config;
 
 import com.tumbloom.tumblerin.global.security.JwtAuthenticationFilter;
 import com.tumbloom.tumblerin.global.security.JwtTokenProvider;
+import com.tumbloom.tumblerin.global.security.SecurityConstants;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,17 +28,7 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(authz -> authz
-                        .requestMatchers(
-                                "/swagger-ui/**",
-                                "/v3/api-docs/**",
-                                "/v3/api-docs",
-                                "/swagger-resources/**",
-                                "/swagger-resources",
-                                "/webjars/**",
-                                "/configuration/**",
-                                "/api/auth/signup",
-                                "/api/auth/login"
-                        ).permitAll()
+                        .requestMatchers(SecurityConstants.AUTH_WHITELIST).permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/tumbloom/tumblerin/global/dto/ErrorCode.java
+++ b/src/main/java/com/tumbloom/tumblerin/global/dto/ErrorCode.java
@@ -18,7 +18,12 @@ public enum ErrorCode {
     SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "서버가 일시적으로 사용 불가 상태입니다."),
     UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 서버 에러가 발생했습니다."),
 
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾지 못했습니다. 토큰이 유효한지 확인해주세요.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾지 못했습니다. 토큰이 유효한지 확인해주세요."),
+
+    //refreshtoken 관련 에러
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "Refresh Token이 유효하지 않습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "저장된 Refresh Token이 존재하지 않습니다."),
+    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "Refresh Token이 일치하지 않습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/tumbloom/tumblerin/global/dto/SuccessCode.java
+++ b/src/main/java/com/tumbloom/tumblerin/global/dto/SuccessCode.java
@@ -20,14 +20,16 @@ public enum SuccessCode {
     RESOURCE_RETRIEVED(HttpStatus.OK, "리소스가 성공적으로 조회되었습니다."),
 
     //사용자 관련
-    USER_CREATED(HttpStatus.CREATED, "사용자가 회원가입에 성공하였습니다."),
     USER_UPDATED(HttpStatus.OK, "사용자 정보가 성공적으로 업데이트되었습니다."),
     USER_LOGGED_IN(HttpStatus.OK, "사용자가 성공적으로 로그인되었습니다."),
     USER_LOGGED_OUT(HttpStatus.OK, "사용자가 성공적으로 로그아웃되었습니다."),
 
     // 인증 관련
+    USER_CREATED(HttpStatus.CREATED, "사용자가 회원가입에 성공하였습니다."),
     LOGIN_SUCCESSFUL(HttpStatus.OK, "로그인에 성공하였습니다."),
-    LOGOUT_SUCCESSFUL(HttpStatus.OK, "로그아웃에 성공하였습니다.");
+    LOGOUT_SUCCESSFUL(HttpStatus.NO_CONTENT, "로그아웃에 성공하였습니다."),
+    TOKEN_REFRESHED(HttpStatus.OK, "Access Token이 재발급되었습니다.");
+
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/tumbloom/tumblerin/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/tumbloom/tumblerin/global/security/JwtTokenProvider.java
@@ -1,12 +1,15 @@
 package com.tumbloom.tumblerin.global.security;
 
 import com.tumbloom.tumblerin.app.security.CustomUserDetailsService;
+import com.tumbloom.tumblerin.global.dto.ErrorCode;
+import com.tumbloom.tumblerin.global.exception.BusinessException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -17,6 +20,7 @@ import java.util.Date;
 
 @RequiredArgsConstructor
 @Component
+@Slf4j
 public class JwtTokenProvider {
 
     private final CustomUserDetailsService userDetailsService;
@@ -26,18 +30,32 @@ public class JwtTokenProvider {
 
     private Key key;
 
-    // access token 유효기간: 30일
-    private final long accessTokenValidTime = 1000L * 60 * 60 * 24 * 30;
+    // access token 유효기간: 30분
+    private final long accessTokenValidTime = 1000L * 60 * 30;
+    // refresh token 발급: 30일
+    private final long refreshTokenValidTime = 1000L * 60 * 60 * 24 * 30;
+
 
     @PostConstruct
     protected void init() {
         this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
     }
 
-    public String createToken(String email) {
+    public String createAccessToken(String email) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + accessTokenValidTime);
 
+        return Jwts.builder()
+                .setSubject(email)
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String createRefreshToken(String email) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + refreshTokenValidTime);
         return Jwts.builder()
                 .setSubject(email)
                 .setIssuedAt(now)
@@ -57,12 +75,41 @@ public class JwtTokenProvider {
                 .parseClaimsJws(token).getBody().getSubject();
     }
 
-    public boolean validateToken(String token) {
+    //accesstoken 검증
+    public void validateToken(String token) {
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
-            return true;
-        } catch (JwtException | IllegalArgumentException e) {
-            return false;
+        } catch (io.jsonwebtoken.security.SecurityException | io.jsonwebtoken.MalformedJwtException e) {
+            log.info("잘못된 JWT 서명입니다.", e);
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_EXCEPTION, "잘못된 JWT 토큰입니다.");
+        } catch (io.jsonwebtoken.ExpiredJwtException e) {
+            log.info("만료된 JWT 토큰입니다.", e);
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_EXCEPTION, "만료된 JWT 토큰입니다.");
+        } catch (io.jsonwebtoken.UnsupportedJwtException e) {
+            log.info("지원하지 않는 JWT 토큰입니다.", e);
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_EXCEPTION, "지원하지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            log.info("JWT 토큰이 비어있습니다.", e);
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_EXCEPTION, "JWT 토큰이 비어있습니다.");
         }
     }
+
+    public void validateRefreshToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+        } catch (io.jsonwebtoken.security.SecurityException | io.jsonwebtoken.MalformedJwtException e) {
+            log.info("잘못된 Refresh JWT 서명입니다.", e);
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_EXCEPTION, "잘못된 Refresh JWT 토큰입니다.");
+        } catch (io.jsonwebtoken.ExpiredJwtException e) {
+            log.info("만료된 Refresh JWT 토큰입니다.", e);
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_EXCEPTION, "만료된 Refresh JWT 토큰입니다.");
+        } catch (io.jsonwebtoken.UnsupportedJwtException e) {
+            log.info("지원하지 않는 Refresh JWT 토큰입니다.", e);
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_EXCEPTION, "지원하지 않는 Refresh JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            log.info("Refresh JWT 토큰이 비어있습니다.", e);
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_EXCEPTION, "Refresh JWT 토큰이 비어있습니다.");
+        }
+    }
+
 }

--- a/src/main/java/com/tumbloom/tumblerin/global/security/SecurityConstants.java
+++ b/src/main/java/com/tumbloom/tumblerin/global/security/SecurityConstants.java
@@ -1,0 +1,16 @@
+package com.tumbloom.tumblerin.global.security;
+
+public class SecurityConstants {
+    public static final String[] AUTH_WHITELIST = {
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/v3/api-docs",
+            "/swagger-resources/**",
+            "/swagger-resources",
+            "/webjars/**",
+            "/configuration/**",
+            "/api/auth/signup",
+            "/api/auth/login",
+            "/api/auth/refresh"
+    };
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #30 

## ✨ 구현 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- refresh token 도입
- 유효기간 설정 및 db 저장, 유효성 검사 도입
- logout api시 refresh token의 전달을 통해 refresh token 무효화 진행
- refresh api를 통해 만료된 accesstoken을 refreshtoken을 통해 재발급
- whitelist api 경로 => securityconstants 에서 통합 관리
- jwttokenprovider에서 모든  token 관련 예외와 로그를 던지도록 리팩터링

