### PR TITLE
Refactor: refreshtoken 전달 방식 수정

### DIFF
--- a/src/main/java/com/tumbloom/tumblerin/app/dto/Authdto/TokenResponseDTO.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/dto/Authdto/TokenResponseDTO.java
@@ -12,7 +12,4 @@ public class TokenResponseDTO {
     @Schema(description = "Access Token", example = "eyJhbGciOiJIUzI1NiIsInR...")
     private String accessToken;
 
-    @Schema(description = "Refresh Token", example = "eyJhbGciOiJIUzI1NiIsInR5c...")
-    private String refreshToken;
-
 }

--- a/src/main/java/com/tumbloom/tumblerin/app/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/tumbloom/tumblerin/app/repository/RefreshTokenRepository.java
@@ -2,7 +2,7 @@ package com.tumbloom.tumblerin.app.repository;
 
 import com.tumbloom.tumblerin.app.domain.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
-
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
+
 
 }


### PR DESCRIPTION
- 기존 refreshtoken 전달방식을 dto에서 httponly cookie로 수정
- logout과 refresh api가 쿠키 값을 받아서 인증하는 방식으로 수정하였습니다
- 추후 배포 이후 cookie secure 설정을 true로 변경 필요( https에서만 동작하도록)

closed #71 