### PR TITLE
Refacor: JWT 만료에 따른 에러 코드 세분화

### DIFF
--- a/src/main/java/com/tumbloom/tumblerin/global/dto/ErrorCode.java
+++ b/src/main/java/com/tumbloom/tumblerin/global/dto/ErrorCode.java
@@ -20,10 +20,13 @@ public enum ErrorCode {
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾지 못했습니다. 토큰이 유효한지 확인해주세요."),
 
-    //refreshtoken 관련 에러
+    //token 관련 에러
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "Refresh Token이 유효하지 않습니다."),
+    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "REFRESH_TOKEN_EXPIRED"),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "저장된 Refresh Token이 존재하지 않습니다."),
-    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "Refresh Token이 일치하지 않습니다.");
+    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "Refresh Token이 일치하지 않습니다."),
+    ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "ACCESS_TOKEN_EXPIRED"),
+    ACCESS_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 액세스 토큰입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/tumbloom/tumblerin/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/tumbloom/tumblerin/global/security/JwtTokenProvider.java
@@ -34,9 +34,9 @@ public class JwtTokenProvider {
     private Key key;
 
     // access token 유효기간: 60분으로 수정
-    private final long accessTokenValidTime = 1000L * 60 * 60;
+    private final long accessTokenValidTime = 1000L * 60 * 3;
     // refresh token 발급: 15일 정도
-    private final long refreshTokenValidTime = 1000L * 60 * 60 * 24 * 15;
+    private final long refreshTokenValidTime = 1000L * 60 * 3; //60 * 24 * 15;
 
 
 
@@ -88,7 +88,7 @@ public class JwtTokenProvider {
             throw new BusinessException(ErrorCode.UNAUTHORIZED_EXCEPTION, "잘못된 JWT 토큰입니다.");
         } catch (io.jsonwebtoken.ExpiredJwtException e) {
             log.info("만료된 JWT 토큰입니다.", e);
-            throw new BusinessException(ErrorCode.UNAUTHORIZED_EXCEPTION, "만료된 JWT 토큰입니다.");
+            throw new BusinessException(ErrorCode.ACCESS_TOKEN_EXPIRED, "ACCESS_TOKEN_EXPIRED");
         } catch (io.jsonwebtoken.UnsupportedJwtException e) {
             log.info("지원하지 않는 JWT 토큰입니다.", e);
             throw new BusinessException(ErrorCode.UNAUTHORIZED_EXCEPTION, "지원하지 않는 JWT 토큰입니다.");
@@ -106,7 +106,7 @@ public class JwtTokenProvider {
             throw new BusinessException(ErrorCode.UNAUTHORIZED_EXCEPTION, "잘못된 Refresh JWT 토큰입니다.");
         } catch (io.jsonwebtoken.ExpiredJwtException e) {
             log.info("만료된 Refresh JWT 토큰입니다.", e);
-            throw new BusinessException(ErrorCode.UNAUTHORIZED_EXCEPTION, "만료된 Refresh JWT 토큰입니다.");
+            throw new BusinessException(ErrorCode.REFRESH_TOKEN_EXPIRED, "REFRESH_TOKEN_EXPIRED");
         } catch (io.jsonwebtoken.UnsupportedJwtException e) {
             log.info("지원하지 않는 Refresh JWT 토큰입니다.", e);
             throw new BusinessException(ErrorCode.UNAUTHORIZED_EXCEPTION, "지원하지 않는 Refresh JWT 토큰입니다.");


### PR DESCRIPTION
- Access Token / Refresh Token의 에러 유스케이스를 세분화
- REFRESH_TOKEN_EXPIRED, ACCESS_TOKEN_EXPIRED 등 명확한 data 값 적용
- 프론트에서 분기 처리 용이하도록 변경

+ 자세한 내용은 노션 참고부탁드립니다!